### PR TITLE
Add network definition 

### DIFF
--- a/lib/chef/knife/vagrant_server.rb
+++ b/lib/chef/knife/vagrant_server.rb
@@ -73,6 +73,13 @@ module KnifePlugins
         require 'vagrant/cli'
       end
 
+      option :networks,
+        :short => '-n NETWORKS',
+        :long => '--networks ',
+        :description => 'Network definitions. Comma separated network entries containing type:data:options Pairs. Where data is network adress or bridge info'
+        :proc => lambda { |o| o.split(/,/).collect { |a| a.split(/:/) } },
+        :default {}
+
       option :port_forward,
         :short => '-p PORTS',
         :long => '--port-forward PORTS',


### PR DESCRIPTION
This adds the ability to create hostonly and bridged networks:
  -n hostonly:172.30.3.1/255.255.255.0,bridged:en0  will add 2 ints first is hostonly with specified addr and mask, second is a bridged interface to en0
