### PR TITLE
don't modifyvm --name

### DIFF
--- a/lib/chef/knife/vagrant_server.rb
+++ b/lib/chef/knife/vagrant_server.rb
@@ -1,4 +1,5 @@
 # knife-vagrant
+>>>>>>> timeout
 # knife plugin for spinning up a vagrant instance and testing a runlist.
 
 module KnifePlugins
@@ -180,7 +181,6 @@ module KnifePlugins
             #{box} 
             config.vm.host_name = "#{config[:hostname]}"
             config.vm.customize [ "modifyvm", :id, "--memory", #{config[:memsize]} ]
-            config.vm.customize [ "modifyvm", :id, "--name", "#{config[:hostname]}" ]
             config.vm.box_url = "#{config[:box_url]}"
             #{build_networks(config[:networks])}
             config.vm.provision :chef_client do |chef|


### PR DESCRIPTION
  Was there a good reason for using modifyvm --name? It doesn't seem very wise to me to do it this way. You already have hostname config option without having to use modifyvm. Aslo the current behavior can cause problems if you build 2 vagrants in different dirs, but with same hostname. This is a totally valid setup in vagrant, but not with knife-vagrant forcing the --name.

I remove this config paramater from our integration build of knife-vagrant, and thought I try to start a discussion.
